### PR TITLE
Handle empty AutoplaceSpecification.control

### DIFF
--- a/processdata/processdata.lua
+++ b/processdata/processdata.lua
@@ -797,7 +797,7 @@ function Process.process_data(data, locales, verbose)
 	local plant_map = {}
 	for name, d in sorted_pairs(data["plant"]) do
 		table.insert(plants, make_plant(locale, d, seed_map))
-		if d.autoplace then
+		if d.autoplace and d.autoplace.control then
 			append(plant_map, d.autoplace.control, name)
 		end
 	end


### PR DESCRIPTION
Version 2.0.21 added the [following bugfix](https://github.com/wube/factorio-data/blob/95147c8b4390ab9975c3d3efd0f9fe8d6ce564b8/changelog.txt#L52):

> Fixed that agricultural tower would show all nauvis tiles as unplantable. Nauvis grass, dirt and red desert are now specifically plantable for tree seeds and highlight as green. (https://forums.factorio.com/122065)

The fix added an autoplace specification to the `tree-plant` prototype without a `control` field ([code here](https://github.com/wube/factorio-data/blob/95147c8b4390ab9975c3d3efd0f9fe8d6ce564b8/space-age/prototypes/entity/plants.lua#L1494)). This is allowed since `control` is optional [according to the API](https://github.com/wube/factorio-data/blob/95147c8b4390ab9975c3d3efd0f9fe8d6ce564b8/space-age/prototypes/entity/plants.lua#L1494). However this causes `nil` to be passed as a key to the `append` function [here](https://github.com/KirkMcDonald/factorio-tools/blob/97a9d95bdd3660dc2adf26633b073cfe4e86cb95/processdata/processdata.lua#L801), resulting in a "table index is nil" error.

This fix ignores the plant entity if its `autoplace.control` field is empty, which restores the previous behavior where `tree-plant` was ignored.