### PR TITLE
Update local recipe specification for calculator

### DIFF
--- a/factoriocalc/main.go
+++ b/factoriocalc/main.go
@@ -24,7 +24,7 @@ var startBrowser = flag.Bool("browser", true, "Whether to automatically launch w
 
 func getOverride(version string) []byte {
 	return []byte(fmt.Sprintf(`"use strict"
-var OVERRIDE = "%s"
+export let OVERRIDE = "%s"
 `, version))
 }
 

--- a/processdata/processdata.lua
+++ b/processdata/processdata.lua
@@ -797,7 +797,7 @@ function Process.process_data(data, locales, verbose)
 	local plant_map = {}
 	for name, d in sorted_pairs(data["plant"]) do
 		table.insert(plants, make_plant(locale, d, seed_map))
-		if d.autoplace then
+		if d.autoplace and d.autoplace.control then
 			append(plant_map, d.autoplace.control, name)
 		end
 	end


### PR DESCRIPTION
The calculator has been updated to use the JavaScript import system so the `OVERRIDE` variable in `override.js` now needs to be exported.

Currently waiting on KirkMcDonald/kirkmcdonald.github.io#260 so that I can also update the `factorio-web-calc` submodule to the correct version as part of this PR.